### PR TITLE
adding timestamp after metric value, to match latest graphite(0.9.12 or ...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/graphiteIntegrator/loggers/GraphiteLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/graphiteIntegrator/loggers/GraphiteLogger.java
@@ -41,7 +41,9 @@ public class GraphiteLogger {
     	Socket conn = new Socket(graphiteHost, Integer.parseInt(graphitePort));
     			
         DataOutputStream dos = new DataOutputStream(conn.getOutputStream());
-        String data = queue + " " + metric + "\n";
+        String data = queue + " " + metric + " " + System.currentTimeMillis() +"\n";
+
+        logger.println("sending " + data + " to graphite server.");
         dos.writeBytes(data);
         
     }


### PR DESCRIPTION
adding timestamp after metric value, to match latest graphite(0.9.12 or later) plain text protocol, as described below:
http://graphite.readthedocs.org/en/latest/feeding-carbon.html#the-plaintext-protocol

> The data sent must be in the following format: <metric path> <metric value> <metric timestamp>.
